### PR TITLE
Feat: 소셜 로그인 OAuth 콜백 처리 추가

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -32,6 +32,7 @@ const Login: React.FC = () => {
       const res = await postLoginLocal({ loginId, password });
 
       if (res.isSuccess) {
+        localStorage.setItem("grantType", res.result.grantType);
         localStorage.setItem("accessToken", res.result.accessToken);
         localStorage.setItem("refreshToken", res.result.refreshToken);
 

--- a/src/pages/OAuthCallbackPage.tsx
+++ b/src/pages/OAuthCallbackPage.tsx
@@ -1,28 +1,35 @@
 import styled from "styled-components";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
 import axios from "axios";
+
+const OAUTH_EXCHANGE_URL = "https://api.bbosongi.com/api/auth/oauth/exchange";
 
 export default function OAuthCallbackPage() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
+  const hasExchangedCode = useRef(false);
 
   const code = searchParams.get("code");
 
   useEffect(() => {
     const exchangeCodeForToken = async () => {
-      if (!code) {
-        alert("로그인 인증 코드가 올바르지 않습니다. ");
-        navigate("/login");
+      if (hasExchangedCode.current) {
         return;
       }
 
+      if (!code) {
+        alert("로그인 인증 코드가 올바르지 않습니다.");
+        navigate("/login", { replace: true });
+        return;
+      }
+
+      hasExchangedCode.current = true;
+
       try {
         const response = await axios.post(
-          "https://api.bbosongi.com/api/auth/oauth/exchange",
-          {
-            code: code,
-          },
+          OAUTH_EXCHANGE_URL,
+          { code },
           {
             headers: {
               "Content-Type": "application/json",
@@ -33,21 +40,21 @@ export default function OAuthCallbackPage() {
         const res = response.data;
 
         if (res.isSuccess) {
-          const { accessToken, refreshToken } = res.result;
+          const { grantType, accessToken, refreshToken } = res.result;
 
+          localStorage.setItem("grantType", grantType);
           localStorage.setItem("accessToken", accessToken);
           localStorage.setItem("refreshToken", refreshToken);
 
-          alert("완료!");
-          navigate("/main-home");
+          navigate("/main-home", { replace: true });
         } else {
           alert(`로그인 실패: ${res.message}`);
-          navigate("/login");
+          navigate("/login", { replace: true });
         }
       } catch (err) {
         console.error("OAuth 토큰 교환 중 서버 오류:", err);
         alert("로그인 처리 중 서버 오류가 발생했습니다.");
-        navigate("/login");
+        navigate("/login", { replace: true });
       }
     };
 
@@ -57,7 +64,7 @@ export default function OAuthCallbackPage() {
   return (
     <LoadingWrapper>
       <Spinner />
-      <LoadingText>로그인 중입니다. 잠시만 기다려주세요... 🧺</LoadingText>
+      <LoadingText>로그인 중입니다. 잠시만 기다려주세요...</LoadingText>
     </LoadingWrapper>
   );
 }
@@ -70,11 +77,13 @@ const LoadingWrapper = styled.div`
   height: 100vh;
   gap: 20px;
 `;
+
 const LoadingText = styled.p`
   font-size: 16px;
   color: #4b80fc;
   font-weight: 500;
 `;
+
 const Spinner = styled.div`
   width: 50px;
   height: 50px;
@@ -82,6 +91,7 @@ const Spinner = styled.div`
   border-top: 5px solid #4b80fc;
   border-radius: 50%;
   animation: spin 1s linear infinite;
+
   @keyframes spin {
     0% {
       transform: rotate(0deg);

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
### 👀 관련 이슈


### ✨ 작업한 내용

- 소셜 로그인 OAuth 콜백 페이지에서 일회용 `code`를 JWT로 교환
- 교환 받은 `grantType`, `accessToken`, `refreshToken` 저장 처리
- OAuth 콜백 code 중복 교환 방지 로직 추가
- 로그인 완료 후 메인 페이지로 이동 처리
- Vercel 배포 환경에서 `/oauth/success` 라우트가 동작하도록 rewrite 설정 추가

### 🌀 PR Point

- 백엔드 OAuth 성공 후 전달되는 `/oauth/success?code=...` 경로에서 code를 읽어 토큰 교환 API를 호출하도록 구현했습니다.
- 1회용 code가 React effect 중복 실행으로 두 번 교환되지 않도록 `useRef`로 요청 중복을 방지했습니다.
- Vercel에서 직접 진입한 SPA 라우트가 404가 되지 않도록 `vercel.json`에 rewrite 설정을 추가했습니다.

### 🍰 참고사항

- `npm.cmd run build` 통과
- 구글 로그인 404 문제는 배포 후 rewrite 설정 반영이 필요합니다.
- 카카오 로그인에서 `AUTH_001`이 계속 발생하면 백엔드의 OAuth 콜백 경로 인증 제외 설정 확인이 필요합니다.

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
| 소셜 로그인 OAuth 콜백 처리 | 해당 없음 |